### PR TITLE
Document OpenAPT solution in integrations

### DIFF
--- a/content/doc/integrations.md
+++ b/content/doc/integrations.md
@@ -13,6 +13,8 @@ Complete solutions:
 
 - [Molior](https://github.com/molior-dbs/molior) Debian Build System by
 André Roth
+- [OpenAPT](https://github.com/allocloud/openapt) by Raphael Medaer and Hubert Lobit (ALLOcloud),
+is a description format for APT repositories and its implementation using aptly.
 
 Vagrant:
 


### PR DESCRIPTION
[OpenAPT](https://openapt.org) is a tool developed by [ALLOcloud](https://allocloud.com) team. It's a file format which allows user to describe APT repositories specifications with a JSON/YAML file. It's also an implementation in Python which automates aptly based on these specifications.

The goal is to document the layout of APT repositories and automate their build with aptly commands. Flow and keywords are inspired by core entities from aptly.