### PR TITLE
Enable HTML rendering to display code blocks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,3 +7,8 @@ title = "Debian repository management tool"
 
 [author]
     name = "Andrey Smirnov"
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true


### PR DESCRIPTION
Enable HTML rendering to display code blocks in Tutorials.
Fixes #82