### PR TITLE
Update Hugo build: requires Go >= 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.16"
+  - 1.16.x
 
 before_script:
   - make prepare

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.14"
+  - "1.16"
 
 before_script:
   - make prepare

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ env:
 
 prepare: env
 
-	go get -u -v github.com/spf13/hugo
+	go get -u -v github.com/gohugoio/hugo
 
 links:
 	linkchecker http://localhost:1313/

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ env:
 
 prepare: env
 
-	go get -u -v github.com/gohugoio/hugo
+	go install github.com/gohugoio/hugo@latest
 
 links:
 	linkchecker http://localhost:1313/


### PR DESCRIPTION
CI can't get and install Hugo packages: [Build #151](https://travis-ci.org/github/aptly-dev/www.aptly.info/builds/766251345)

Hugo >= 0.81.0 only builds with >= Go 1.16.

github.com/spf13/hugo redirects to github.com/gohugoio/hugo, but Go 1.16 don't allow redirects by default:
```
# go get -u -v github.com/spf13/hugo; echo $?
go: downloading github.com/spf13/hugo v0.82.0
go get: github.com/spf13/hugo@v0.47.1 updating to
        github.com/spf13/hugo@v0.82.0: parsing go.mod:
        module declares its path as: github.com/gohugoio/hugo
                but was required as: github.com/spf13/hugo
1
```
So we need to update Hugo URL also.