### PR TITLE
Documentation for TPM support as implemented in #953

### DIFF
--- a/content/doc/aptly/publish.md
+++ b/content/doc/aptly/publish.md
@@ -36,3 +36,10 @@ Signing releases is highly recommended, but if you want to skip it, you
 can either use `gpgDisableSign` configuration option or `--skip-signing`
 flag.
 
+For all commands in this section which accept a `-secret-keyring=""` argument,
+when the "internal" Go-native OpenPGP implementation is in use, this keyring
+can be of the form `tpm://HANDLE?dev=DEVICE` to use a key stored in the
+system's Trusted Platform Module. `HANDLE` should be in a form similar to
+`0x81000000`, and `DEVICE` should be the URL-escaped name of a device similar
+to `/dev/tpmrm0` (which happens to be the default); URL-escaped, this would be
+expressed as `?dev=%2Fdev%2Ftpmrm0`.


### PR DESCRIPTION
Should not be merged without aptly-dev/aptly#953.