### PR TITLE
Fix link from API repos to aptly repo include

### DIFF
--- a/content/doc/api/repos.md
+++ b/content/doc/api/repos.md
@@ -211,7 +211,7 @@ Example (file upload, add package to repo):
 
 New in {{< version "1.4.0" >}}
 
-Allows automatic processing of `.changes` file controlling package upload (uploaded using [File Upload API](/doc/api/files)) to the local repository. Exposes [repo include](/doc/repo/include) command in api.
+Allows automatic processing of `.changes` file controlling package upload (uploaded using [File Upload API](/doc/api/files)) to the local repository. Exposes [repo include](/doc/aptly/repo/include) command in api.
 
 Query params:
 


### PR DESCRIPTION
The link to aptly repo changed, or was wrong. Update it to point to the
`aptly repo include` command documentation as intended.