### PR TITLE
content: publish: Fix typo on switch docs

### DIFF
--- a/content/doc/aptly/publish/switch.md
+++ b/content/doc/aptly/publish/switch.md
@@ -32,7 +32,7 @@ Params:
     default to empty endpoint (local file system).
 -   `prefix` is publishing prefix, if not specified, it would default to
     empty prefix (`.`).
--   `new-snapshot` is a snapshot name that snould be re-published
+-   `new-snapshot` is a snapshot name that should be re-published
 
 Flags:
 


### PR DESCRIPTION
Fix type: s/snould/should

Signed-off-by: Ariel D'Alessandro <ariel.dalessandro@collabora.com>