### PR TITLE
S3: add docs for `acl: none` value

### DIFF
--- a/content/doc/feature/s3.md
+++ b/content/doc/feature/s3.md
@@ -25,8 +25,8 @@ associated settings:
 -   `prefix`: (optional) do publishing under specified prefix in the
     bucket, defaults to no prefix (bucket root)
 -   `acl`: (optional) assign ACL to published files (one of the canned
-    ACLs in Amazon terminology). Useful values: `private` (default) or
-    `public-read` (public repository). Public repositories could be
+    ACLs in Amazon terminology). Useful values: `private` (default),
+    `public-read` (public repository) or `none` (don't set ACL). Public repositories could be
     consumed by `apt` using HTTP endpoint (Amazon bucket should be
     configured for "website hosting"), for private repositories special
     apt S3 transport is required.


### PR DESCRIPTION
This new configuration value was added in 1.5.0 with this PR:

- https://github.com/aptly-dev/aptly/pull/1087