### PR TITLE
Add linkMethod relative symlink

### DIFF
--- a/content/doc/feature/filesystem.md
+++ b/content/doc/feature/filesystem.md
@@ -25,11 +25,19 @@ Example:
       },
       "test2": {
         "rootDir": "/opt/srv2/aptly_public",
-        "linkMethod": "copy",
-        "verifyMethod": "md5"
+        "linkMethod": "absoluteSymlink"
       },
       "test3": {
         "rootDir": "/opt/srv3/aptly_public",
+        "linkMethod": "relativeSymlink"
+      },
+      "test4": {
+        "rootDir": "/opt/srv4/aptly_public",
+        "linkMethod": "copy",
+        "verifyMethod": "md5"
+      },
+      "test5": {
+        "rootDir": "/opt/srv5/aptly_public",
         "linkMethod": "hardlink"
       }
     },
@@ -41,8 +49,9 @@ Each endpoint has a name and the following associated settings:
    * `rootDir`:
      The publish directory, e.g., `/opt/srv/aptly_public`.
    * `linkMethod`:
-     This is one of `hardlink`, `symlink` or `copy`. It specifies how aptly links the
+     This is one of `hardlink`, `symlink`, `absoluteSymlink`, `relativeSymlink` or `copy`. It specifies how aptly links the
      files from the internal pool to the published directory.
+     The option `symlink` will be treated as `absoluteSymlink`
      If not specified, empty or wrong, this defaults to `hardlink`.
    * `verifyMethod`:
      This is used only when setting the `linkMethod` to `copy`. Possible values are


### PR DESCRIPTION
Add document with the new option: `relativeSymlink`
We have total 3 options: `relativeSymlink`, `absoluteSymlink` and `symlink`. `symlink` will be treated as `absoluteSymlink`
Pull request here https://github.com/aptly-dev/aptly/pull/1092

