### PR TITLE
Fix hugo author deprecation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.139.0'
           # extended: true
 
       - name: Build

--- a/config.toml
+++ b/config.toml
@@ -5,9 +5,8 @@ title = "Debian repository management tool"
 
 [params]
     DisqusShortname = "aptly"
-
-[author]
-    name = "Andrey Smirnov"
+  [params.author]
+      name = "Andrey Smirnov"
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
Fixes #92 

Fixes a deprecated config option Hugo has, and pins Hugo to 0.139.0 so we don't unintentionally hit this again. 