### PR TITLE
integrations: add ansible role by hetzner cloud

### DIFF
--- a/content/doc/integrations.md
+++ b/content/doc/integrations.md
@@ -29,6 +29,7 @@ Docker:
 With configuration management systems:
 
 - [Ansible role](https://github.com/aioue/ansible-role-aptly) by Tom Paine
+- [Ansible role](https://github.com/hetznercloud/ansible-role-aptly) by Hetzner Cloud
 - [Chef cookbook](https://github.com/hw-cookbooks/aptly) by Aaron Baer
 (Heavy Water Operations, LLC)
 - [Puppet module](https://github.com/alphagov/puppet-aptly) by


### PR DESCRIPTION
Hetzner Cloud uses aptly internally and published its role to the public which they use. It supports idempotent repository and mirror configuration.